### PR TITLE
Updates for recovering files in processed state

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,24 @@ $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-po
 ```bash
 $ poetry install
 ```
+## Configure Cast Iron (using Ray Worker)
+
+1. Retrieve the Cast Iron project (https://github.com/black-cape/cast-iron)
+1. Replace the Worker_Dockerfile with the one included in this project
 
 ## Start the Worker
 
 1. Add `127.0.0.1 kafka` entry to your /etc/hosts file
-1. Start the Cast-Iron ETL worker
+1. Start the Cast-Iron Ray-based ETL worker
     * Locally
     ```
     $ poetry shell
     $ uvicorn --host 0.0.0.0 --port 8080 etl.app_manager:app
     ```
       - To run with a debugger use `python worker.py`
-    * Docker
+    * Docker (with the Cast Iron Project)
     ```
-    $ docker-compose up --build
+    $ docker-compose -f docker-compose-single.yml up --build 
     ```
 
 ## Utlize the ETL

--- a/Worker_Dockerfile
+++ b/Worker_Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.8-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=true
+
+# Using a different directory than /usr/src/app to allow volume mounting of code to /usr/src/app for local development
+WORKDIR /opt/setup
+
+RUN apt-get update && \
+  apt-get -y install gcc g++ && \
+  python -m pip install --upgrade pip && \
+  pip install --upgrade poetry
+COPY . /opt/setup
+RUN poetry install --no-dev --no-interaction --no-ansi
+
+FROM ghcr.io/black-cape/ray-worker:latest
+
+RUN apt-get update && \
+  apt-get -y install gcc g++
+
+# Copy the virtual environment from the first stage so we can set the Python path to it's packages
+# avoiding the need to install any of the dependencies
+COPY --from=0 /opt/setup/.venv /opt/setup/.venv
+# Set additional Python paths to expose libraries installed in previous stages
+ENV PYTHONPATH="/usr/local/lib/python3.8/site-packages/:/opt/setup/.venv/lib/python3.8/site-packages:$PYTHONPATH"
+ENV PATH="$PATH:/opt/setup/.venv/bin"
+

--- a/etl/database/database.py
+++ b/etl/database/database.py
@@ -62,7 +62,11 @@ class PGDatabase(DatabaseStore):
     async def insert_file(self, filedata: FileObject):
         """ Track a new file from Minio"""
         LOGGER.info("Inserting file into DB...")
-        await self._database.insert('files', dict(filedata))
+        try:
+            await self._database.insert('files', dict(filedata))
+        except Exception:
+            await self._table_manager.update(filedata['id'], filedata)
+
 
     async def move_file(self, rowid: str, new_name: str):
         """ Track the moving of a file in Minio"""

--- a/etl/general_event_processor.py
+++ b/etl/general_event_processor.py
@@ -62,6 +62,8 @@ class GeneralEventProcessor:
 
                     metadata = json.loads(stalled_file['metadata'])
                     metadata.pop('originalFilename', None)
+                    metadata.pop('X-Amz-Meta-Originalfilename', None)
+                    metadata.pop('X-Amz-Meta-Id', None)
 
                     LOGGER.error(f"Moving file: {stalled_file['file_name']} back to original filename: {new_path} to restart processing...")
 

--- a/etl/general_event_processor.py
+++ b/etl/general_event_processor.py
@@ -67,7 +67,10 @@ class GeneralEventProcessor:
 
                     LOGGER.error(f"Moving file: {stalled_file['file_name']} back to original filename: {new_path} to restart processing...")
 
-                    self._object_store.move_object(src_object_id, dest_object_id, metadata)
+                    try:
+                        self._object_store.move_object(src_object_id, dest_object_id, metadata)
+                    except Exception as e:
+                        LOGGER.error(f"Error restoring file.  Possible database/Minio mismatch: {e}")
 
 
     async def process(self, evt_data: Dict) -> None:

--- a/etl/messaging/kafka_consumer.py
+++ b/etl/messaging/kafka_consumer.py
@@ -125,7 +125,7 @@ class ConsumerWorker:
                 time.sleep(5)
                 continue
             try:
-                LOGGER.error(f"Received messages: {len(records_dict.items())}")
+                LOGGER.info(f"Received messages: {len(records_dict.items())}")
 
                 for topic_partition, consumer_records in records_dict.items():
                     for record in consumer_records:

--- a/etl/messaging/kafka_consumer.py
+++ b/etl/messaging/kafka_consumer.py
@@ -92,7 +92,7 @@ class ConsumerWorker:
                                         enable_auto_commit=settings.kafka_enable_auto_commit,
                                         max_poll_records=settings.kafka_max_poll_records,
                                         max_poll_interval_ms=settings.kafka_max_poll_interval_ms,
-                                        consumer_timeout_ms=1000)
+                                        consumer_timeout_ms=30000)
             self.consumer.subscribe([settings.kafka_topic_castiron_etl_source_file])
             LOGGER.error(f'Started consumer worker for topic {settings.kafka_topic_castiron_etl_source_file}...')
         except KafkaError as exc:
@@ -119,9 +119,10 @@ class ConsumerWorker:
                 LOGGER.error(f"Error from file check: {e}")
             
         while not self.stop_worker:
-            records_dict = self.consumer.poll(timeout_ms=self.poll_timeout_ms)
+            records_dict = self.consumer.poll(timeout_ms=self.poll_timeout_ms, max_records=1)
 
             if records_dict is None or len(records_dict.items()) == 0:
+                time.sleep(5)
                 continue
             try:
                 LOGGER.error(f"Received messages: {len(records_dict.items())}")

--- a/etl/toml_processor.py
+++ b/etl/toml_processor.py
@@ -1,5 +1,6 @@
 """Contains the implementation of the EventProcessor class"""
 import ray
+import re
 from typing import Dict, Optional
 
 from etl.config import settings
@@ -53,6 +54,14 @@ class TOMLProcessor:
             cfg: FileProcessorConfig = try_loads(data)
 
             if cfg.enabled:
+                if cfg.handled_file_glob:
+                    #Validate regex expression if provided
+                    try:
+                        re.compile(cfg.handled_file_glob)
+                    except re.error as e:
+                        LOGGER.error(f"Invalid regex provided.  Unable to register TOML.  Error: {e}")
+                        return False
+
                 # Register processor
                 self.processors[toml_object_id] = cfg
                 LOGGER.info('number of processor configs: %s', len(self.processors))


### PR DESCRIPTION
This PR is to update the worker to support recovery of processes that have been interrupted.  The worker queries the DB to determine any existing files in the "Processing" state on startup and moves those files back into the queue for reprocessing.

Testing:
- Start up services as normal
- Place a file in the appropriate directory for processing
- Stop the docker container for `ray-worker` prior to completion
- Restart the worker and validate that the file is moved through the folders to complete by watch Minio or worker logs.