### PR TITLE
Event Loop ObjectRefs

### DIFF
--- a/etl/general_event_processor.py
+++ b/etl/general_event_processor.py
@@ -225,7 +225,8 @@ class GeneralEventProcessor:
     async def _event_loop(self):
         local_database = ClickHouseDatabase()
         while True:
-            unfinished = list(self._pending_tasks.keys())
+            # make sure ray.wait gets ObjectRefs, not DictKeys
+            unfinished = [object_ref for object_ref in self._pending_tasks.keys()]
             while unfinished:
                 self.logger.debug('Found unfinished tasks to wait for')
                 finished, unfinished = ray.wait(unfinished, num_returns=1)


### PR DESCRIPTION
This MR updates the event_loop to iterate through pending task object refs to make sure ObjectRefs are provided to ray.wait rather than DictKeys, fixing the TypeError being thrown by ray.wait described here: https://blackcape.atlassian.net/browse/RBCN-849?atlOrigin=eyJpIjoiZjljYjlkM2NlODk5NDhiYzgyYTIxOTI2MDBiYTQ2MzIiLCJwIjoiaiJ9